### PR TITLE
Configured the CMake scripts to generate an OpenGL template project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+project(OpenGLTemplate CXX)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+# Set directory paths
+set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+set(sources ${SOURCE_DIR}/main.cpp)
+
+add_executable(opengl-template ${sources} ${includes})
+
+# Perform dependency linkage
+include(${CMAKE_DIR}/LinkGLFW.cmake)
+LinkGLFW(opengl-template PRIVATE)
+
+include(${CMAKE_DIR}/LinkGLAD.cmake)
+LinkGLAD(opengl-template PRIVATE)
+
+find_package(OpenGL REQUIRED)
+target_include_directories(opengl-template PRIVATE ${OPENGL_INCLDUE_DIRS})
+target_link_libraries(opengl-template PRIVATE ${OPENGL_LIBRARIES})
+
+# Enable C++17
+set_target_properties(opengl-template PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO)
+
+# Set project folders
+set_target_properties(opengl-template PROPERTIES FOLDER ${PROJECT_NAME})

--- a/cmake/LinkGLAD.cmake
+++ b/cmake/LinkGLAD.cmake
@@ -1,0 +1,39 @@
+include(FetchContent)
+
+macro(LinkGLAD TARGET ACCESS)
+    FetchContent_Declare(
+        glad
+        GIT_REPOSITORY https://github.com/Dav1dde/glad
+        GIT_TAG v0.1.33
+    )
+
+    FetchContent_GetProperties(glad)
+
+    if (NOT glad_POPULATED)
+        FetchContent_Populate(glad)
+
+        # Edit these values to generate the desired loader-generator
+        set(GLAD_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE STRING "Output directory")
+        set(GLAD_PROFILE "core" CACHE STRING "OpenGL profile")
+        set(GLAD_API "gl=3.3" CACHE STRING "API type/version pairs, like \"gl=3.2,gles=\", no version means latest")
+        set(GLAD_GENERATOR "c" CACHE STRING "Language to generate the binding for")
+        set(GLAD_EXTENSIONS "" CACHE STRING "Path to extensions file or comma separated list of extensions, if missing all extensions are included")
+        set(GLAD_SPEC "gl" CACHE STRING "Name of the spec")
+        option(GLAD_ALL_EXTENSIONS "Include all extensions instead of those specified by GLAD_EXTENSIONS" OFF)
+        option(GLAD_NO_LOADER "No loader" OFF)
+        option(GLAD_REPRODUCIBLE "Reproducible build" OFF)
+
+        # This excludes glad from being rebuilt when ALL_BUILD is built
+        # it will only be built when a target is built that has a dependency on glad
+        add_subdirectory(${glad_SOURCE_DIR} ${glad_BINARY_DIR} EXCLUDE_FROM_ALL)
+
+        # Set the target's folders
+        set_target_properties(glad PROPERTIES FOLDER ${PROJECT_NAME}/thirdparty)
+        set_target_properties(glad-generate-files PROPERTIES FOLDER ${PROJECT_NAME}/thirdparty)
+    endif()
+
+    target_include_directories(${TARGET} ${ACCESS} ${glad_SOURCE_DIR}/include)
+    target_link_libraries(${TARGET} ${ACCESS} glad)
+
+    add_dependencies(${TARGET} glad)
+endmacro()

--- a/cmake/LinkGLFW.cmake
+++ b/cmake/LinkGLFW.cmake
@@ -1,0 +1,33 @@
+include(FetchContent)
+
+macro(LinkGLFW TARGET ACCESS)
+    FetchContent_Declare(
+        glfw
+        GIT_REPOSITORY https://github.com/glfw/glfw
+        GIT_TAG 3.3.2
+    )
+
+    FetchContent_GetProperties(glfw)
+
+    if (NOT glfw_POPULATED)
+        FetchContent_Populate(glfw)
+
+        # Just configure GLFW only
+        set(GLFW_BUILD_EXAMPLES OFF)
+        set(GLFW_BUILD_TESTS OFF)
+        set(GLFW_BUILD_DOCS OFF)
+        set(GLFW_INSTALL OFF)
+
+        # This excludes glfw from being rebuilt when ALL_BUILD is built
+        # it will only be built when a target is built that has a dependency on glfw
+        add_subdirectory(${glfw_SOURCE_DIR} ${glfw_BINARY_DIR} EXCLUDE_FROM_ALL)
+
+        # Set the target's folders
+        set_target_properties(glfw PROPERTIES FOLDER ${PROJECT_NAME}/thirdparty)
+    endif()
+
+    target_include_directories(${TARGET} ${ACCESS} ${glfw_SOURCE_DIR}/include)
+    target_link_libraries(${TARGET} ${ACCESS} glfw)
+
+    add_dependencies(${TARGET} glfw)
+endmacro()

--- a/cmake/LinkSTB.cmake
+++ b/cmake/LinkSTB.cmake
@@ -1,0 +1,17 @@
+include(FetchContent)
+
+macro(LinkSTB TARGET ACCESS)
+    FetchContent_Declare(
+        stb
+        GIT_REPOSITORY https://github.com/nothings/stb
+        GIT_TAG b42009b3b9d4ca35bc703f5310eedc74f584be58
+    )
+
+    FetchContent_GetProperties(stb)
+
+    if (NOT stb_POPULATED)
+        FetchContent_Populate(stb)
+    endif()
+
+    target_include_directories(${TARGET} ${ACCESS} ${stb_SOURCE_DIR})
+endmacro()

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+void ProcessInput(GLFWwindow* window)
+{
+    if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
+        glfwSetWindowShouldClose(window, true);
+}
+
+int main()
+{
+    glfwInit();
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+    // Construct the window
+    GLFWwindow* window = glfwCreateWindow(800, 600, "OpenGL Template", nullptr, nullptr);
+    if (!window)
+    {
+        std::cout << "Failed to create the GLFW window\n";
+        glfwTerminate();
+    }
+
+    glfwMakeContextCurrent(window);
+
+    if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
+    {
+        std::cout << "Failed to initialize GLAD\n";
+        return -1;
+    }
+
+    // Handle view port dimensions
+    glViewport(0, 0, 800, 600);
+    glfwSetFramebufferSizeCallback(window, [](GLFWwindow* window, int width, int height)
+    {
+        glViewport(0, 0, width, height);
+    });
+
+    // This is the render loop
+    while (!glfwWindowShouldClose(window))
+    {
+        ProcessInput(window);
+
+        // Druids are the best
+        glClearColor(1.00, 0.49, 0.04, 1.00);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        glfwSwapBuffers(window);
+        glfwPollEvents();
+    }
+
+    glfwTerminate();
+    return 0;
+}


### PR DESCRIPTION
This contains the CMake project files that generate an OpenGL template. Dependencies (GLFW, GLAD) are automatically pulled down and linked with the main project. This only works for **Windows**, currently. Will add support for other platforms later.

The GLAD loader generation uses some hardcoded values. To change, see LinkGLAD.cmake and modify the cache variables accordingly.